### PR TITLE
Vari Fix dei Messaggi

### DIFF
--- a/pages/messages/eraseall.inc.php
+++ b/pages/messages/eraseall.inc.php
@@ -1,9 +1,21 @@
 <?php
-gdrcd_query("DELETE FROM messaggi WHERE destinatario = '".$_SESSION['login']."' AND letto = 1");
-?>
-<div class="warning">
-    <?php echo gdrcd_filter('out', $PARAMETERS['names']['private_message']['sing'].$MESSAGE['interface']['messages']['erased']); ?>
-</div>
-<div class="link_back">
-    <a href="main.php?page=messages_center&offset=0"><?php echo gdrcd_filter('out', $MESSAGE['interface']['messages']['go_back']); ?></a>
-</div>
+
+// In base alla tipologia di visualizzazione, elimino i relativi messaggi letti
+if(gdrcd_filter_in($_POST['type']) === 'destinatario_del') {
+    $query = "UPDATE messaggi SET destinatario_del = 1 WHERE destinatario='".gdrcd_filter('in', $_SESSION['login'])."' AND letto = 1";
+} elseif(gdrcd_filter_in($_POST['type']) === 'mittente_del') {
+    $query = "UPDATE messaggi SET mittente_del = 1 WHERE mittente='".gdrcd_filter('in', $_SESSION['login'])."' AND letto = 1";
+}
+
+// Avvio l'operazione
+if(isset($query)){
+    // Eseguo la query
+    gdrcd_query($query);
+
+    // Mostro il messaggio
+    ?>
+    <div class="warning">
+        <?php echo gdrcd_filter('out', $PARAMETERS['names']['private_message']['plur'].$MESSAGE['interface']['messages']['all_erased']); ?>
+    </div>
+    <?php
+}

--- a/pages/messages/index.inc.php
+++ b/pages/messages/index.inc.php
@@ -153,11 +153,26 @@ $numresults = gdrcd_query($result, 'num_rows');
                     </td>
                 </tr>
                 <?php
-                $_SESSION['last_istant_message'] = $row['id'];
+
+                // Salvo l'id dell'ultimo messaggio ricevuto per consentire le notifiche in caso di nuovi messaggi
+                if($_GET['op'] != 'inviati') {
+                    // Se non ho ancora stabilito un ultimo id o quello che sto scrivendo ha un id più alto rispetto a quello già salvato, allora lo salvo
+                    if(!isset($lastMessageReceived) || $row['id'] > $lastMessageReceived) {
+                        $lastMessageReceived = $row['id'];
+                    }
+                }
+
             }//while
 
             gdrcd_query($result, 'free');
-            gdrcd_query("UPDATE personaggio SET ultimo_messaggio = ".$_SESSION['last_istant_message']." WHERE nome='".$_SESSION['login']."'");
+
+            // Aggiorno l'ultimo messaggio visualizzato
+            if(isset($lastMessageReceived)){
+                // Salvo l'ID nella sessione
+                $_SESSION['last_istant_message'] = $lastMessageReceived;
+                // Salvo l'ID nella riga del personaggio
+                gdrcd_query("UPDATE personaggio SET ultimo_messaggio = ".$lastMessageReceived." WHERE nome='".$_SESSION['login']."'");
+            }
             ?>
         </table>
         <?php

--- a/pages/messages/index.inc.php
+++ b/pages/messages/index.inc.php
@@ -47,40 +47,28 @@ $numresults = gdrcd_query($result, 'num_rows');
                     <!-- Icona -->
                 </td>
                 <td>
-            <span class="titoli_elenco">
-                <?php if($_GET['op'] == 'inviati') {
-                    echo "Destinatario";
-                } else {
-                    echo gdrcd_filter('out', $MESSAGE['interface']['messages']['sender']);
-                }
-                ?>
-            </span>
-                </td>
-                <td width="185" align="left" valign="bottom">
-            <span class="titoli_elenco" style="font-weight:bold;">
-                <?php
-                if($_GET['op'] == 'inviati') {
-                    echo "Inviato il";
-                } else {
-                    echo gdrcd_filter('out', $MESSAGE['interface']['messages']['date']);
-                }
-                ?>
-            </span>
-                </td>
-                <td width="192" align="left" valign="bottom">
-            <span class="titoli_elenco" style="font-weight:bold;">
-                <?php echo gdrcd_filter('out', $MESSAGE['interface']['messages']['preview']); ?>
- 	        </span>
+                    <span class="titoli_elenco">
+                        <?php if($_GET['op'] == 'inviati') {
+                            echo "Destinatario";
+                        } else {
+                            echo gdrcd_filter('out', $MESSAGE['interface']['messages']['sender']);
+                        }
+                        ?>
+                    </span>
                 </td>
                 <td>
- 	        <span class="titoli_elenco">
- 	            <?php echo gdrcd_filter('out', $MESSAGE['interface']['messages']['date']); ?>
- 	        </span>
+                    <span class="titoli_elenco">
+                        <?php
+                        echo ($_GET['op'] == 'inviati')
+                            ? "Inviato il"
+                            : gdrcd_filter('out', $MESSAGE['interface']['messages']['date']);
+                        ?>
+                    </span>
                 </td>
                 <td>
-    	    <span class="titoli_elenco">
- 	            <?php echo gdrcd_filter('out', $MESSAGE['interface']['messages']['preview']); ?>
- 	        </span>
+                    <span class="titoli_elenco">
+                        <?php echo gdrcd_filter('out', $MESSAGE['interface']['messages']['preview']); ?>
+                    </span>
                 </td>
                 <td>
                     <!-- Controlli -->

--- a/pages/messages/index.inc.php
+++ b/pages/messages/index.inc.php
@@ -176,12 +176,21 @@ $numresults = gdrcd_query($result, 'num_rows');
             ?>
         </table>
         <?php
-        echo '<div>
-          <form id="multiple_delete" method="post" action="main.php?page=messages_center" onSubmit="return checked_copy();">
-            <input type="hidden" name="op" value="erase_checked" />
-            <input type="hidden" name="type" value="'.$delType.'" />
-            <input type="submit" value="Cancella Messaggi Selezionati">
-          </form>
+        echo '<div class="pulsanti_elenco">
+                <!-- //Pulsante elimina messaggi selezionati-->
+                <form id="multiple_delete" method="post" action="main.php?page=messages_center" onSubmit="return checked_copy();">
+                    <input type="hidden" name="op" value="erase_checked" />
+                    <input type="hidden" name="type" value="'.$delType.'" />
+                    <input type="submit" value="Cancella Messaggi Selezionati">
+                </form>
+                <!-- //Pulsante elimina messaggi letti-->
+                <form action="main.php?page=messages_center'.($_GET['op'] == 'inviati' ? '&op=inviati' : '').'" method="post">
+                    <div class="form_submit">
+                        <input type="hidden" name="op" value="eraseall" />
+                        <input type="hidden" name="type" value="'.$delType.'" />
+                        <input type="submit" value="Cancella tutti i Messaggi Letti" />
+                    </div>
+                </form>
         </div>';
     } else {
         if($totaleresults > $PARAMETERS['settings']['messages_limit']) {
@@ -207,12 +216,6 @@ $numresults = gdrcd_query($result, 'num_rows');
 <div class="link_back">
     <a href="main.php?page=messages_center&op=create">
         <?php echo $MESSAGE['interface']['messages']['new']; ?>
-    </a>
-</div>
-<!-- link scrivi messaggio -->
-<div class="link_back">
-    <a href="main.php?page=messages_center&op=eraseall">
-        <?php echo $MESSAGE['interface']['messages']['erase_all']; ?>
     </a>
 </div>
 <script type="text/javascript">

--- a/pages/messages/send_message.inc.php
+++ b/pages/messages/send_message.inc.php
@@ -58,4 +58,3 @@ if (gdrcd_filter('get', $_POST['multipli']) == 'singolo') {
     <div class="warning">
         <?php echo $PARAMETERS['names']['private_message']['sing'] . $MESSAGE['interface']['messages']['sent']; ?>
     </div>
-<?php

--- a/pages/messages_center.inc.php
+++ b/pages/messages_center.inc.php
@@ -21,7 +21,7 @@ include_once('../header.inc.php');
                 include('messages/erase_checked.inc.php');
                 break;
             case 'eraseall': //Eliminazione di tutti i messaggi
-                include ('messages/eraseall.inc.php');
+                include('messages/eraseall.inc.php');
                 break;
             case 'send_message': //Inserimento nuovo messaggio nel db
                 include('messages/send_message.inc.php');

--- a/themes/advanced/messaggi.css
+++ b/themes/advanced/messaggi.css
@@ -16,6 +16,15 @@ div.pagina_messages_center div.elementi_elenco {
     height: 40px;
 }
 
+/*Testo delle colonne*/
+div.pagina_messages_center div.pulsanti_elenco {
+    display: inline-block;
+}
+
+div.pagina_messages_center div.pulsanti_elenco form {
+    float: left;
+}
+
 /*************************/
 /*Visualizzazione del messaggio singolo*/
 div.read_message_box {
@@ -61,4 +70,4 @@ div.read_message_box_form {
 div.read_message_box_form input {
     height: 20px;
     width: 20px;
-} 
+}

--- a/themes/basic/messaggi.css
+++ b/themes/basic/messaggi.css
@@ -16,6 +16,15 @@ div.pagina_messages_center div.elementi_elenco {
     height: 40px;
 }
 
+/*Testo delle colonne*/
+div.pagina_messages_center div.pulsanti_elenco {
+    display: inline-block;
+}
+
+div.pagina_messages_center div.pulsanti_elenco form {
+    float: left;
+}
+
 /*************************/
 /*Visualizzazione del messaggio singolo*/
 div.read_message_box {


### PR DESCRIPTION
Qui le correzioni apportate:
- Rimosse colonne duplicate nell'elenco dei messaggi;
- Rimossa apertura tag php non necessaria nell'invio di un messaggio;
- Corretto il metodo per il salvataggio dell'ultimo id messaggio visualizzato in elenco, per migliorare il controllo sui nuovi messaggi;
- Ripristinata la funzione 'Cancella tutti i messaggi letti', sia per i Ricevuti che per gli Inviati.