### PR TITLE
GDRCD 5.6 - Query fix

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -96,7 +96,11 @@ function gdrcd_query($sql, $mode = 'query')
             return mysqli_fetch_array($sql, MYSQLI_BOTH);
             break;
 
-        case 'object':
+        case 'assoc':
+            return mysqli_fetch_array($sql, MYSQLI_ASSOC);
+            break;        
+		
+		case 'object':
             return mysqli_fetch_object($sql);
             break;
 


### PR DESCRIPTION
var_dump(gdrcd_query($result, 'fetch'));
array (size=4)
  0 => string '1' (length=1)
  'id' => string '1' (length=1)
  1 => string 'Strada' (length=6)
  'nome' => string 'Strada' (length=6)

var_dump(gdrcd_query($result, 'assoc'));
array (size=2)
  'id' => string '1' (length=1)
  'nome' => string 'Strada' (length=6)