### PR TITLE
GDRCD 5.6.0.4 - Revisione Presentazione in Homepage

### DIFF
--- a/pages/homepage/home.inc.php
+++ b/pages/homepage/home.inc.php
@@ -7,23 +7,19 @@
     Stai utilizzando la versione <strong><?=$PARAMETERS['info']['GDRCD']?></strong> di GDRCD, sviluppata dal <a href="https://github.com/orgs/GDRCD/people" target="_blank">Team di GDRCD</a>
     sulla base del lavoro fatto da <strong>Salvatore (Blancks) Rotondo</strong> e <strong>breaker</strong> con <strong>GDRCD 5.1</strong>.
 </p>
-    In questa versione di GDRCD sono state implementate nuove features su iniziativa del Team di GDRCD o provenienti dalla communità di
-    <a href="https://gdr-online.com/" target="_blank">GdR-Online.com</a>, quest'ultime completamente riviste
-    per essere quanto più personalizzabili in base alle esigenze.
 <p>
-    I files <strong>non sono retrocompatibili</strong> nei riguardi di <strong>GDRCD 5.4</strong> di <strong>breaker</strong>
+    È possibile consultare i cambiamenti che vengono effettuatti di versione in versione nei <a href="https://github.com/GDRCD/GDRCD/releases" target="_blank">changelog ufficiali</a> del software.
+</p>
+<p>
+    I files <strong>non sono retrocompatibili</strong> nei riguardi di <strong>GDRCD 5.4</strong> di <strong>breaker</strong>,
     tuttavia il software è progettato per <strong>rilevare il database di un installazione precedente ed aggiornarlo autonomamente</strong>
     al fine di renderlo compatibile con la presente versione.
 </p>
 <p>
-    Puoi trovare tutte le informazioni sulle modifiche eseguite sulla repository ufficiale di <a href="https://github.com/GDRCD/GDRCD">GitHub</a>
-    a questo <a href="https://github.com/GDRCD/GDRCD/releases/tag/<?=$PARAMETERS['info']['GDRCD']?>">indirizzo</a>.
+    Troverai le istruzioni su come utilizzare GDRCD nel <a href="ISTRUZIONI.txt">manuale</a> allegato.
 </p>
 <p>
     Prima di iniziare a realizzare il tuo sito, hai letto la <a href="license.md">licenza d'uso</a> che accompagna il prodotto? Se non l'hai ancora fatto premurati gentilmente di leggerla.
-</p>
-<p>
-    Troverai le istruzioni su come utilizzare GDRCD <?=$PARAMETERS['info']['GDRCD']?> nel <a href="ISTRUZIONI.txt">manuale</a> allegato.
 </p>
 <p>
     Se vuoi contribuire al progetto e al suo sviluppo dai un occhiata al <a href="http://www.gdr-online.com/readforum.asp?id=137092">topic dedicato</a> su <a href="https://gdr-online.com/" target="_blank">GdR-Online.com</a>,

--- a/pages/homepage/home.inc.php
+++ b/pages/homepage/home.inc.php
@@ -11,9 +11,9 @@
     È possibile consultare i cambiamenti che vengono effettuatti di versione in versione nei <a href="https://github.com/GDRCD/GDRCD/releases" target="_blank">changelog ufficiali</a> del software.
 </p>
 <p>
-    I files <strong>non sono retrocompatibili</strong> nei riguardi di <strong>GDRCD 5.4</strong> di <strong>breaker</strong>,
-    tuttavia il software è progettato per <strong>rilevare il database di un installazione precedente ed aggiornarlo autonomamente</strong>
-    al fine di renderlo compatibile con la presente versione.
+    La versione 5.6 <strong>non è retrocompatibile</strong> con le versioni inferiori alla 5.5,
+    poichè dalla versione 5.5 è stato introdotto un sistema di <strong>rilevamento di modifiche progressive al database di un installazione precedente con aggiornamento automatico</strong>
+    al fine di rendere le versioni superiori alla 5.5 compatibili con quelle successive.
 </p>
 <p>
     Troverai le istruzioni su come utilizzare GDRCD nel <a href="ISTRUZIONI.txt">manuale</a> allegato.


### PR DESCRIPTION
Ulteriormente aggiornata la presentazione in Homepage in modo da essere ancora più sintetica, raccogliendo solo le informazioni essenziali per il progetto senza dover per forza modificare questa pagina di versione in versione.