### PR TITLE
GDRCD 6 - Php8 integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ includes/config-overrides.php
 .directory
 .user.ini
 **/compiled
+php_errors.log

--- a/core/classes/Libraries/Routing.class.php
+++ b/core/classes/Libraries/Routing.class.php
@@ -68,7 +68,7 @@ class Router
      * @return bool
      * @throws Exception
      */
-    private final function loadLibraries(string $className): bool
+    private function loadLibraries(string $className): bool
     {
 
         $path = ROOT . '/core/classes';
@@ -96,7 +96,7 @@ class Router
      * @return void
      * @throws Exception
      */
-    private final function loadController(string $className)
+    private function loadController(string $className)
     {
         $path = ROOT . '/includes/default/classes';
         $roots = $this->dirList($path);
@@ -128,7 +128,7 @@ class Router
      * @param array $results
      * @return array
      */
-    private final function dirList(string $dir, array &$results = []): array
+    private function dirList(string $dir, array &$results = []): array
     {
 
         $files = scandir($dir);

--- a/includes/default/classes/Controller/Chat/Chat.class.php
+++ b/includes/default/classes/Controller/Chat/Chat.class.php
@@ -418,7 +418,7 @@ class Chat extends BaseClass
 
         # Ritorno le sue icone estratte
         $races = DB::query("
-                SELECT razza.icon,razza.nome_razza,personaggio.sesso
+                SELECT razze.icon,razze.nome AS nome_razza,personaggio.sesso
                 FROM personaggio 
                 LEFT JOIN razze ON (razze.id = personaggio.razza)
                 WHERE personaggio.id = '{$mittente}'", 'result');

--- a/includes/default/classes/Controller/Chat/Chat.class.php
+++ b/includes/default/classes/Controller/Chat/Chat.class.php
@@ -1240,14 +1240,14 @@ class Chat extends BaseClass
     private function saveDice(array $array): void
     {
         # Filtro le variabili necessarie
-        $dice = Filters::in($array['dice']);
+        $dice = Filters::int($array['dice']);
         $abi_nome = Filters::in($array['abi_nome']);
-        $abi_dice = Filters::in($array['abi_dice']);
-        $car_dice = Filters::in($array['car_dice']);
+        $abi_dice = Filters::int($array['abi_dice']);
+        $car_dice = Filters::int($array['car_dice']);
         $car_name = Filters::in($array['car_name']);
-        $car_bonus = Filters::in($array['car_bonus']);
+        $car_bonus = Filters::int($array['car_bonus']);
         $obj_nome = Filters::in($array['obj_nome']);
-        $obj_dice = Filters::in($array['obj_dice']);
+        $obj_dice = Filters::int($array['obj_dice']);
         $total = 0;
 
         # Inizializzo il testo con una parte comune
@@ -1264,7 +1264,7 @@ class Chat extends BaseClass
         $total += $car_dice;
 
         # Se ho selezionato la possibilita' di aggiungere i bonus equipaggiamento al totale della stat
-        if ( $car_bonus !== '' ) {
+        if ( $car_bonus ) {
             $html .= "Bonus Equip Stat {$car_bonus},";
             $total += $car_bonus;
         }

--- a/includes/default/classes/Controller/Meteo/MeteoStagioni.class.php
+++ b/includes/default/classes/Controller/Meteo/MeteoStagioni.class.php
@@ -43,9 +43,10 @@ class MeteoStagioni extends Meteo
      * @note Estrae tutte le condizioni meteo di una stagione
      * @param int $id
      * @param string $val
+     * # TODO - Da rivedere
      * @return array
      */
-    public function getAllSeasonCondition(int $id, string $val = 'meteo_stagioni_condizioni.*, meteo_condizioni.*')
+    public function getAllSeasonCondition(int $id, string $val = 'meteo_stagioni_condizioni.*, meteo_condizioni.*'): array
     {
         $output = [];
         $stmt = DB::query("SELECT {$val} FROM meteo_stagioni_condizioni LEFT JOIN meteo_condizioni ON meteo_stagioni_condizioni.condizione = meteo_condizioni.id WHERE meteo_stagioni_condizioni.stagione='{$id}'", 'result');

--- a/includes/default/classes/Controller/Meteo/MeteoStagioni.class.php
+++ b/includes/default/classes/Controller/Meteo/MeteoStagioni.class.php
@@ -43,11 +43,19 @@ class MeteoStagioni extends Meteo
      * @note Estrae tutte le condizioni meteo di una stagione
      * @param int $id
      * @param string $val
-     * @return bool|int|mixed|string
+     * @return array
      */
     public function getAllSeasonCondition(int $id, string $val = 'meteo_stagioni_condizioni.*, meteo_condizioni.*')
     {
-        return DB::query("SELECT {$val} FROM meteo_stagioni_condizioni LEFT JOIN meteo_condizioni ON meteo_stagioni_condizioni.condizione = meteo_condizioni.id WHERE meteo_stagioni_condizioni.stagione='{$id}'", 'result');
+        $output = [];
+        $stmt = DB::query("SELECT {$val} FROM meteo_stagioni_condizioni LEFT JOIN meteo_condizioni ON meteo_stagioni_condizioni.condizione = meteo_condizioni.id WHERE meteo_stagioni_condizioni.stagione='{$id}'", 'result');
+
+        if (DB::query($stmt, 'num_rows')) {
+            while ($output[] = DB::query($stmt, 'fetch'));
+            DB::query($stmt,'free');
+        }
+
+        return $output;
     }
 
     /**
@@ -175,10 +183,10 @@ class MeteoStagioni extends Meteo
     /**
      * @fn renderSeasonList
      * @note Sotto-funzione per regole di renderizzazione della lista stagioni in gestione
-     * @param object $list
+     * @param array $list
      * @return array
      */
-    public function renderSeasonConditionList(object $list): array
+    public function renderSeasonConditionList(array $list): array
     {
 
         $row_data = [];

--- a/includes/default/classes/Controller/Personaggio/PersonaggioAbilita.class.php
+++ b/includes/default/classes/Controller/Personaggio/PersonaggioAbilita.class.php
@@ -70,8 +70,8 @@ class PersonaggioAbilita extends Personaggio
     public function getPgRaceAbility(int $pg, string $val = 'abilita.*,personaggio_abilita.*')
     {
         # Estaggo la razza del pg
-        $pg_data = Personaggio::getPgData($this->me_id, 'razza AS id_razza');
-        $race = Filters::int($pg_data['id_razza']);
+        $pg_data = Personaggio::getPgData($this->me_id, 'razza');
+        $race = Filters::int($pg_data['razza']);
 
         return DB::query("SELECT {$val} FROM personaggio_abilita 
                                 LEFT JOIN abilita ON (personaggio_abilita.abilita = abilita.id)

--- a/includes/default/classes/Controller/Personaggio/PersonaggioAbilita.class.php
+++ b/includes/default/classes/Controller/Personaggio/PersonaggioAbilita.class.php
@@ -70,7 +70,7 @@ class PersonaggioAbilita extends Personaggio
     public function getPgRaceAbility(int $pg, string $val = 'abilita.*,personaggio_abilita.*')
     {
         # Estaggo la razza del pg
-        $pg_data = Personaggio::getPgData($this->me_id, 'id_razza');
+        $pg_data = Personaggio::getPgData($this->me_id, 'razza AS id_razza');
         $race = Filters::int($pg_data['id_razza']);
 
         return DB::query("SELECT {$val} FROM personaggio_abilita 

--- a/includes/default/pages/messages/send_message.inc.php
+++ b/includes/default/pages/messages/send_message.inc.php
@@ -52,7 +52,6 @@ switch ( $opRequest ) {
             if ( isset($queryInsert) ) {
                 $query = gdrcd_query("INSERT INTO messaggi (mittente, destinatario, spedito, tipo, oggetto, testo) VALUES " . implode(",", $queryInsert));
                 $query = gdrcd_query("INSERT INTO backmessaggi (mittente, destinatario, spedito, tipo, oggetto, testo) VALUES " . implode(",", $queryInsert));
-                gdrcd_query($query, 'free');
             }
 
             echo '<div class="warning">' . $PARAMETERS['names']['private_message']['sing'] . $MESSAGE['interface']['messages']['sent'] . '</div>';


### PR DESCRIPTION
Questa PR risolve i punti critici che impedivano alla versione 6 di girare sotto PHP >= 8.0.
Adesso si riesce ad effettuare il login, usare i messaggi privati, le mappe, le bacheche e le chat con relative sottofunzioni. Altre sezioni interne come la scheda pg e alcune pagine di gestione potrebbero funzionare già regolarmente, ma non sono ancora state testate.