### PR TITLE
GDRCD 5.6.0.6 - Allineamento utilizzo informazioni personaggio in scheda e correzione audio

### DIFF
--- a/pages/scheda.inc.php
+++ b/pages/scheda.inc.php
@@ -60,9 +60,9 @@
          */
         if($PARAMETERS['mode']['alert_password_change'] == 'ON') {
             $six_months = 15552000;
-            $ts_signup = strtotime($record['data_iscrizione']);
-            $ts_lastpass = (int) strtotime($record['ultimo_cambiopass']);
-            if($ts_lastpass + $six_months < time() && $record['nome'] == $_SESSION['login']) {
+            $ts_signup = strtotime($personaggio['data_iscrizione']);
+            $ts_lastpass = (int) strtotime($personaggio['ultimo_cambiopass']);
+            if($ts_lastpass + $six_months < time() && $personaggio['nome'] == $_SESSION['login']) {
                 $message = ($ts_signup + $six_months < time()) ? $MESSAGE['warning']['changepass'] : $MESSAGE['warning']['changepass_signup'];
                 echo '<div class="warning">'.$message.'</div>';
             }
@@ -90,7 +90,7 @@
                 <div class="iscritto_da">
                     <?php echo gdrcd_filter('out', $MESSAGE['interface']['sheet']['first_login']).' '.gdrcd_format_date($personaggio['data_iscrizione']); ?>
                 </div>
-                <?php if(gdrcd_format_date($record['ora_entrata']) != '00/00/0000') { ?>
+                <?php if(gdrcd_format_date($personaggio['ora_entrata']) != '00/00/0000') { ?>
                     <div class="ultimo_ingresso">
                         <?php echo gdrcd_filter('out', $MESSAGE['interface']['sheet']['last_login']).' '.gdrcd_format_date($personaggio['ora_entrata']); ?>
                     </div>
@@ -114,7 +114,7 @@
                 <div class="titolo_box">
                     <?php echo gdrcd_filter('out', $MESSAGE['interface']['sheet']['box_title']['profile']); ?>
                 </div>
-                <?php if($record['permessi'] > 0) { ?>
+                <?php if($personaggio['permessi'] > 0) { ?>
                     <div class="profilo_voce">
                         <div class="profilo_voce_label">
                             <?php echo gdrcd_filter('out', $MESSAGE['interface']['sheet']['profile']['role']); ?>:
@@ -263,13 +263,14 @@
     <?php
     /********* CHIUSURA SCHEDA **********/
     //Impedisci XSS nella musica
-    $record['url_media'] = gdrcd_filter('fullurl', $record['url_media']);
-    if($PARAMETERS['mode']['allow_audio'] == 'ON' && ! $_SESSION['blocca_media'] && ! empty($record['url_media'])) { ?>
+    $personaggio['url_media'] = gdrcd_filter('fullurl', $personaggio['url_media']);
+    if($PARAMETERS['mode']['allow_audio'] == 'ON' && !$_SESSION['blocca_media'] && !empty($personaggio['url_media'])) { ?>
         <audio autoplay>
-            <source src="<?php echo $record['url_media']; ?>" type="audio/mpeg">
+            <source src="<?php echo $personaggio['url_media']; ?>" type="<?php echo $PARAMETERS['settings']['audiotype']['.' . strtolower(end(explode('.', $personaggio['url_media'])))]; ?>">
+            Your browser does not support the audio element.
         </audio>
         <!--[if IE9]>
-        <embed src="<?php echo $record['url_media']; ?>" autostart="true" hidden="true"/>
+        <embed src="<?php echo $personaggio['url_media']; ?>" autostart="true" hidden="true"/>
         <![endif]-->
     <?php } ?>
 </div><!-- Pagina -->

--- a/pages/scheda/skillsystem.inc.php
+++ b/pages/scheda/skillsystem.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 //carico le sole abilità del pg
 $abilita = gdrcd_query("SELECT id_abilita, grado FROM clgpersonaggioabilita WHERE nome='".gdrcd_filter('in', $_REQUEST['pg'])."'", 'result');
 
@@ -11,11 +12,17 @@ while($row = gdrcd_query($abilita, 'fetch')) {
     $ranks[$row['id_abilita']] = $row['grado'];
 }
 
-$personaggio=gdrcd_query("SELECT id_razza, esperienza FROM personaggio WHERE nome='".gdrcd_filter('in', $_REQUEST['pg'])."'", 'query');
+// In caso non siano state estratte in precedenza informazioni sul personaggio, le riottengo
+if(!isset($personaggio['id_razza']) || !isset($personaggio['esperienza']) ) {
+    // Eseguo la query
+    $personaggioInfo = gdrcd_query("SELECT id_razza, esperienza FROM personaggio WHERE nome='".gdrcd_filter('in', $_REQUEST['pg'])."'", 'query');
+    // Salvo i dati
+    $personaggio['id_razza'] = $personaggioInfo['id_razza'];
+    $personaggio['esperienza'] = $personaggioInfo['esperienza'];
+}
 
-
+// Calcolo il totale di esperienza del personaggio
 $px_totali_pg = gdrcd_filter('int', $personaggio['esperienza']) ;
-
 
 ?>
 <div class="elenco_abilita"><!-- Elenco abilità -->

--- a/pages/scheda_modifica.inc.php
+++ b/pages/scheda_modifica.inc.php
@@ -18,9 +18,7 @@
     if ($PARAMETERS['mode']['allow_audio'] == 'ON')
     {
 
-        if ( ! empty($_POST['modifica_url_media']) && ! isset($PARAMETERS['settings']['audiotype']['.' . strtolower(end(explode('.',
-                    $_POST['modifica_url_media'])))])
-        )
+        if ( ! empty($_POST['modifica_url_media']) && ! isset($PARAMETERS['settings']['audiotype']['.' . strtolower(end(explode('.', $_POST['modifica_url_media'])))]) )
         {
             echo '<div class="warning">' . gdrcd_filter('out', $MESSAGE['warning']['media_not_allowed']) . '</div>';
             $confirm_updating = false;


### PR DESCRIPTION
Questa modifica corregge un refuso di un vecchio aggiornamento della scheda per il quale si era passato dall'utilizzo della variabile **_$record_** per contenere le informazioni del personaggio alla variabile **_$personaggio_** . Ciò impediva a diverse funzionalità di essere scatenate, tra cui i controlli sulla longevità della password dell'account. 

Oltre questo, è stato anche inibito il potenziale conflitto tra la pagina della scheda e quella delle skill poichè quest'ultima andava a sovrascrivere la variabile **_$personaggio_** e toglieva la possibilità di riprodurre i contenuti multimediali impostati con **URL MEDIA**.

È stato aggiornato anche il controllo sulla tipologia di file eseguibile nel tag <audio> in scheda.