### PR TITLE
Fix sussurri non rivolti a me con notifica sonora

### DIFF
--- a/ref_header.inc.php
+++ b/ref_header.inc.php
@@ -345,7 +345,7 @@ if((gdrcd_filter_get($_REQUEST['chat']) == 'yes') && (empty($_SESSION['login']) 
 
         // identifico se l'ultimo messaggio è dell'utente o meno
         $isLastMessageFromUser = ($row['mittente'] == $_SESSION['login']);
-        //@Author: Branci89
+        
         //dobbiamo capire se un eventuale sussurro è rivolto a me.
         $whisperToMe = false; 
         switch($row['tipo']) {
@@ -394,7 +394,6 @@ if((gdrcd_filter_get($_REQUEST['chat']) == 'yes') && (empty($_SESSION['login']) 
                 break;
             case 'S':
                 if($_SESSION['login'] == $row['destinatario']) {
-                    //@Author: Branci89 
                     //il sussurro è rivolto a me, quindi vero. 
                     $whisperToMe = true;
                     $add_chat .= '<span class="chat_name">'.$row['mittente'].' '.$MESSAGE['chat']['whisper']['by'].': </span> ';
@@ -434,7 +433,7 @@ if((gdrcd_filter_get($_REQUEST['chat']) == 'yes') && (empty($_SESSION['login']) 
     gdrcd_query($query, 'free');
 
     // Prevedo la notifica in caso di nuovi messaggi
-    //@Author: Brancix aggiungo il flag per verificare che il sussurro sia per me, così da lanciare la notifica
+    //aggiungo il flag per verificare che il sussurro sia per me, così da lanciare la notifica
     if($_SESSION['last_message'] > 0 && (isset($isLastMessageFromUser) && !$isLastMessageFromUser) && $whisperToMe && (isset($add_chat) && $add_chat != '')){
         $playAudioController = AudioController::play('chat', TRUE);;
     }

--- a/ref_header.inc.php
+++ b/ref_header.inc.php
@@ -345,7 +345,9 @@ if((gdrcd_filter_get($_REQUEST['chat']) == 'yes') && (empty($_SESSION['login']) 
 
         // identifico se l'ultimo messaggio è dell'utente o meno
         $isLastMessageFromUser = ($row['mittente'] == $_SESSION['login']);
-
+        //@Author: Branci89
+        //dobbiamo capire se un eventuale sussurro è rivolto a me.
+        $whisperToMe = false; 
         switch($row['tipo']) {
             case 'A':
             case 'P':
@@ -392,6 +394,9 @@ if((gdrcd_filter_get($_REQUEST['chat']) == 'yes') && (empty($_SESSION['login']) 
                 break;
             case 'S':
                 if($_SESSION['login'] == $row['destinatario']) {
+                    //@Author: Branci89 
+                    //il sussurro è rivolto a me, quindi vero. 
+                    $whisperToMe = true;
                     $add_chat .= '<span class="chat_name">'.$row['mittente'].' '.$MESSAGE['chat']['whisper']['by'].': </span> ';
                     $add_chat .= '<span class="chat_msg">'.gdrcd_filter('out', $row['testo']).'</span>';
                 } elseif($_SESSION['login'] == $row['mittente']) {
@@ -429,7 +434,8 @@ if((gdrcd_filter_get($_REQUEST['chat']) == 'yes') && (empty($_SESSION['login']) 
     gdrcd_query($query, 'free');
 
     // Prevedo la notifica in caso di nuovi messaggi
-    if($_SESSION['last_message'] > 0 && (isset($isLastMessageFromUser) && !$isLastMessageFromUser) && (isset($add_chat) && $add_chat != '')){
+    //@Author: Brancix aggiungo il flag per verificare che il sussurro sia per me, così da lanciare la notifica
+    if($_SESSION['last_message'] > 0 && (isset($isLastMessageFromUser) && !$isLastMessageFromUser) && $whisperToMe && (isset($add_chat) && $add_chat != '')){
         $playAudioController = AudioController::play('chat', TRUE);;
     }
 


### PR DESCRIPTION
Ho fixato un bug che faceva scattare la notifica sonora in chat anche per dei sussurri non inviati a me. 
Il problema era nel controllo su $add_chat che nelle recenti versioni è sempre inizializzato e diverso da stringa vuota. 

ho aggiunto un flag per risolvere il problema, testato in locale funziona come dovrebbe