### PR TITLE
GDRCD 5.6 - Risolti errori tipi in functions.inc.php

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -35,7 +35,7 @@ function gdrcd_connect()
 
 /**
  * Chiusura della connessione col db MySql
- * @param resource $db : una connessione mysqli
+ * @param mysqli $db : una connessione mysqli
  */
 function gdrcd_close_connection($db)
 {
@@ -56,7 +56,7 @@ function gdrcd_close_connection($db)
  *  free: libera la memoria occupata dalla risorsa mysqli passata in $sql
  *  last_id: ritorna l'id del record generato dall'ultima query, se non era una INSERT o UPDATE ritorna 0. In questo caso $sql non viene considerato
  *  affected: ritorna il numero di record toccati dall'ultima query (INSERT, UPDATE, DELETE o SELECT). In questo caso $sql non viene considerato
- * @return boolean : un booleano in caso di esecuzione di query non SELECT e modalità 'query'. Altrimenti ritorna come specificato nella descrizione di $mode
+ * @return mixed boolean : un booleano in caso di esecuzione di query non SELECT e modalità 'query'. Altrimenti ritorna come specificato nella descrizione di $mode
  * @throws Exception
  */
 function gdrcd_query($sql, $mode = 'query', $throwOnError = false)
@@ -253,6 +253,7 @@ function gdrcd_check_tables($table)
 function gdrcd_mysql_error($details = false)
 {
     $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 50);
+    $history = '';
 
     foreach($backtrace as $v) {
         if($v['function'] == 'gdrcd_query') {
@@ -356,7 +357,7 @@ function gdrcd_filter($what, $str)
             break;
 
         case 'includes':
-            $str = (preg_match("#[^:]#is")) ? htmlentities($str, ENT_QUOTES) : false;
+            $str = (preg_match("#[^:]#is", $str)) ? htmlentities($str, ENT_QUOTES) : false;
             break;
 
         case 'url':


### PR DESCRIPTION
This pull request includes several improvements and fixes to the `includes/functions.inc.php` file. The most important changes involve correcting parameter types, fixing regular expression usage, and adding error handling details.

### Parameter Type Corrections:
* [`gdrcd_close_connection($db)`](diffhunk://#diff-7f5c83cd6a5198f5f4eb3a374820652ccab1b446423a181f81e920810ac7844aL38-R38): Changed the parameter type from `resource` to `mysqli` to accurately reflect the expected input.

### Return Type Corrections:
* `gdrcd_query($sql, $mode = 'query', $throwOnError = false)`: Corrected the return type documentation to indicate it returns a mixed type, primarily a boolean.

### Error Handling:
* [`gdrcd_mysql_error($details = false)`]: Added the `$history` variable to store error backtrace details for better debugging.

### Regular Expression Fix:
* `gdrcd_filter($what, $str)`: Fixed the regular expression in the `includes` case to properly validate the input string. (`[includes/functions.inc.phpL359-R360]