### PR TITLE
Correzione permessi Chat

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -28,9 +28,11 @@ if( ! empty($_SESSION['login'])) {
     }
 
     if(isset($_REQUEST['dir']) && is_numeric($_REQUEST['dir'])) {
+        $_SESSION['luogo_precedente'] = $_SESSION['luogo'];
         $_SESSION['luogo'] = $_REQUEST['dir'];
     }
 }
+ 
 
 /* INFORMAZIONI SU GDRCD */
 $PARAMETERS['info']['GDRCD'] = '5.6.0.6'; //versione di GDRCD

--- a/login.php
+++ b/login.php
@@ -82,6 +82,7 @@ if( ! empty($record) and gdrcd_password_check($pass1, $record['pass']) && ($reco
     $_SESSION['luogo'] = (empty($record['ultimo_luogo']) === true) ? -1 :  $_SESSION['luogo'] = $record['ultimo_luogo'];
     $_SESSION['tag'] = "";
     $_SESSION['last_message'] = 0;
+    $_SESSION['luogo_precedente'] = -1; 
 
     $res = gdrcd_query("SELECT ruolo.gilda, ruolo.immagine FROM ruolo JOIN clgpersonaggioruolo ON clgpersonaggioruolo.id_ruolo = ruolo.id_ruolo WHERE clgpersonaggioruolo.personaggio = '".gdrcd_filter('in', $record['nome'])."'", 'result');
 

--- a/pages/frame_chat.inc.php
+++ b/pages/frame_chat.inc.php
@@ -27,6 +27,7 @@ $info = gdrcd_query("SELECT nome, stanza_apparente, invitati, privata, proprieta
         //se e' privata e l'utente non ha titolo di leggerla
         if($allowance === false) {
             echo '<div class="warning">'.$MESSAGE['chat']['whisper']['privat'].'</div>';
+            $_SESSION['luogo'] = $_SESSION['luogo_precedente'];
 
             //echo $info['invitati']; echo gdrcd_capital_letter($_SESSION['login']);
         } else {


### PR DESCRIPTION
Inserimento di una session che verifica la chat sulla quale si sta effettivamente cercando di entrare, per evitare che chi non è invitato possa leggere le chat private