### PR TITLE
GDRCD 5.6 - Correzione inserimento messaggio di benvenuto

### DIFF
--- a/pages/homepage/iscrizione.inc.php
+++ b/pages/homepage/iscrizione.inc.php
@@ -522,7 +522,7 @@
                                 echo '<div class="panels_box"><div class="welcome_message">' . gdrcd_filter('out', $MESSAGE['register']['welcome']['message'][0]) . ' <b>' . gdrcd_filter('out', $PARAMETERS['info']['site_name']) . '</b> ' . gdrcd_filter('out', $MESSAGE['register']['welcome']['message'][1]) . '</div><div class="welcome_message">' . gdrcd_filter('out', $MESSAGE['register']['welcome']['message'][2]) . '</div><div class="username">' . gdrcd_filter('out', $MESSAGE['register']['welcome']['message']['user']) . ' <b>' . gdrcd_safe_name($_POST['nome']) . '</b></div><div class="username">' . gdrcd_filter('out', $MESSAGE['register']['welcome']['message']['pass']) . ' <b>' . $pass . '</b></div></div>';
                             }
 
-                            gdrcd_query("INSERT INTO messaggi (mittente, destinatario, spedito, testo) VALUES ('" . gdrcd_filter('out', $PARAMETERS['info']['webmaster_name']) . "', '" . gdrcd_safe_name($_POST['nome']) . "', NOW(), '" . gdrcd_filter('out', $MESSAGE['register']['welcome']['message'][4]) . "')");
+                            gdrcd_query("INSERT INTO messaggi (mittente, destinatario, spedito, testo) VALUES ('" . gdrcd_filter('out', $PARAMETERS['info']['webmaster_name']) . "', '" . gdrcd_safe_name($_POST['nome']) . "', NOW(), '" . gdrcd_filter('in', $MESSAGE['register']['welcome']['message'][4]) . "')");
                     }
                 }
                 echo '</div>


### PR DESCRIPTION
 il problema sta tutto sulla pagina di iscrizione in questo punto:
`gdrcd_query("INSERT INTO messaggi (mittente, destinatario, spedito, testo) VALUES ('" . gdrcd_filter('out', $PARAMETERS['info']['webmaster_name']) . "', '" . gdrcd_safe_name($_POST['nome']) . "', NOW(), '" . gdrcd_filter('in', $MESSAGE['register']['welcome']['message'][4]) . "')");`

trattandosi di una query di inserimento sul db, bisognerebbe usare il filtro "in" e non "out", che penso sia quello che vada a manipolare il tutto anche se il db e le impostazioni sono tutte utf8.

Infatti, se si manda un messaggio normale con accenti funziona correttamente. Il problema sembra isolato al solo messaggio di iscrizione