### PR TITLE
5.6 - spostato link nuovi esiti

### DIFF
--- a/pages/gestione/segnalazioni/esiti_master.php
+++ b/pages/gestione/segnalazioni/esiti_master.php
@@ -233,13 +233,16 @@ if ($_SESSION['permessi'] >= ESITI_PERM && ESITI) {
                 <?php } #Fine blocco  ?>
             </table>
         </div>
+        
+    <?php
+        }
+        ?>
         <div class="link_back">
             <a href='main.php?page=gestione_segnalazioni&segn=esito_index&op=first'>
                 Apri una nuova serie di esiti
             </a>
         </div>
     <?php
-        }
     }
 } else {
     echo '<div class="warning">Non hai i permessi per visualizzare questa sezione</div>';

--- a/pages/servizi_esiti.inc.php
+++ b/pages/servizi_esiti.inc.php
@@ -189,13 +189,17 @@
                         </table>
                     </div>
                     <!-- link nuova serie esiti -->
-                    <div class="link_back">
+                    
+                    <?php
+                }
+                ?>
+                <div class="link_back">
                         <a href='main.php?page=servizi_esitinew&op=first'>
                             Apri una nuova serie di esiti
                         </a>
                     </div>
-                    <?php
-                }
+
+            <?php 
             }
         ?>
     </div>


### PR DESCRIPTION
Il bottone per creare i nuovi esiti si trovava all'interno del  while che genera la tabella nel caso cui ci fossero esiti. Nell'eventualità non ci fossero segnalazioni (come in una nuova installazione ad esempio), i bottoni non vengono mostrati.

Ho spostato il div che contiene il link dal while per risolvere