### PR TITLE
[v5.7] - Risolve incremento abilità non funzionante per PG con nome particolare

### DIFF
--- a/pages/scheda/skillsystem.inc.php
+++ b/pages/scheda/skillsystem.inc.php
@@ -31,7 +31,7 @@ $px_totali_pg = gdrcd_filter('int', $personaggio['esperienza']) ;
     </div>
     <?php
     //Incremento skill
-    if((gdrcd_filter('get', $_REQUEST['op']) == 'addskill') && (($_SESSION['login'] == gdrcd_filter('out', $_REQUEST['pg'])) || ($_SESSION['permessi'] >= MODERATOR))) {
+    if((gdrcd_filter('get', $_REQUEST['op']) == 'addskill') && (($_SESSION['login'] == gdrcd_filter('get', $_REQUEST['pg'])) || ($_SESSION['permessi'] >= MODERATOR))) {
         $px_necessari = $PARAMETERS['settings']['px_x_rank'] * ($ranks[$_REQUEST['what']] + 1);
         if(($px_totali_pg - $px_spesi) >= $px_necessari) {
             $px_spesi += $px_necessari;


### PR DESCRIPTION
Questa correzione punta a risolvere la segnalazione #369 , sostituendo `gdrcd_filter('out', ...)` con `gdrcd_filter('get', ...)` per far sì che vengano applicati gli addslashes e quindi validati anche nomi cone caratteri speciali. 