### PR TITLE
[v5.7] - Fix engine migrazioni e nuova convenzione nomi

### DIFF
--- a/db_versions/2025073023_GDRCD57_Convert_Chat_To_Utf8mb4.php
+++ b/db_versions/2025073023_GDRCD57_Convert_Chat_To_Utf8mb4.php
@@ -1,6 +1,6 @@
 <?php
 
-class GDRCD57 extends DbMigration
+class GDRCD57_Convert_Chat_To_Utf8mb4 extends DbMigration
 {
     /**
      * @inheritDoc

--- a/includes/DbMigration/DbMigration.class.php
+++ b/includes/DbMigration/DbMigration.class.php
@@ -17,7 +17,7 @@ abstract class DbMigration
             $myReflection = new ReflectionClass($this);
             $definitionFile = $myReflection->getFileName();
             $filen = basename($definitionFile, '.php');
-            $parts = explode('_', $filen);
+            $parts = explode('_', $filen, 2);
             if(count($parts) > 1) {//Salviamoci in caso di nomenclatura errata
                 $this->migration_id = (int)$parts[0];//l'id migrazione deve essere il primo componente del nome file
             }

--- a/includes/DbMigration/DbMigration.class.php
+++ b/includes/DbMigration/DbMigration.class.php
@@ -10,7 +10,7 @@ abstract class DbMigration
      * migrazione nel formato YYYYMMDDHH (esempio: 2021103018)
      */
     protected $migration_id = 0;
-    
+
     public function __construct()
     {
         if($this->migration_id <= 0){
@@ -23,20 +23,20 @@ abstract class DbMigration
             }
         }
     }
-    
+
     public function getMigrationId(){
         if($this->migration_id <= 0){
             throw new Exception("Migration ID non configurato per " . get_called_class());
         }
-        
+
         return $this->migration_id;
     }
-    
+
     /**
      * Implementazione delle modifiche che questa migration deve eseguire sul DB quando viene applicata
      */
     abstract public function up();
-    
+
     /**
      * Implementazione delle modifiche che questa migration deve eseguire sul DB quando viene rimossa
      */

--- a/includes/DbMigration/DbMigrationEngine.class.php
+++ b/includes/DbMigration/DbMigrationEngine.class.php
@@ -6,7 +6,7 @@
 class DbMigrationEngine
 {
     const MIGRATIONS_FOLDER = __DIR__ . '/../../db_versions/';
-    
+
     /**
      * @fn updateDbSchema
      * @note Esegue le modifiche allo schema del DB portandolo alla versione specificata
@@ -20,14 +20,14 @@ class DbMigrationEngine
         $migrations = self::loadMigrationClasses();
         self::createVersioningTable();//Per sicurezza cerchiamo di crearla sempre
         $lastApplied = self::getLastAppliedMigration();
-        
+
         if(empty($lastApplied)) {
             self::performDbSetup($migrations, $lastApplied);
         }
-    
+
         $directionUp = true;
         $migrationsToApply = self::getMigrationsToApply($migrations, $lastApplied, $migration_id, $directionUp);
-        
+
         $applied = 0;
         mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);//Necessario per le transazioni
         $connection = gdrcd_connect();
@@ -51,10 +51,10 @@ class DbMigrationEngine
                 throw new Exception("Aggiornamento del database fallito: " . $e->getMessage(), 0, $e);
             }
         }
-        
+
         return $applied;
     }
-    
+
     /**
      * @fn dbNeedsInstallation
      * @note Indica se il database di GDRCD è stato installato o meno
@@ -63,7 +63,7 @@ class DbMigrationEngine
     public static function dbNeedsInstallation() {
         return self::getTablesCountInDb() <= 1;//Controlliamo sempre 1 e non 0, per escludere la tabella delle  migration
     }
-    
+
     /**
      * @fn dbNeedsUpdate
      * @note Indica se il database non si trova all'ultima versione disponibile e necessita quindi di applicare una
@@ -75,14 +75,14 @@ class DbMigrationEngine
         if(self::dbNeedsInstallation()){
             return true;
         }
-    
+
         $migrations = self::loadMigrationClasses();
         self::createVersioningTable();//Per sicurezza cerchiamo di crearla sempre
         $lastApplied = self::getLastAppliedMigration();
-    
+
         return empty($lastApplied) or $migrations[count($migrations) -1]->getMigrationId() != (int)$lastApplied['migration_id'];
     }
-    
+
     /**
      * @fn getAllAvailableMigration
      * @note Restituisce un array di tutte le migration disponibili a sistema
@@ -92,7 +92,7 @@ class DbMigrationEngine
     public static function getAllAvailableMigrations(){
         return self::loadMigrationClasses();
     }
-    
+
     /**
      * @fn loadMigrationClasses
      * @note Carica in memoria le classi di migrazione
@@ -103,7 +103,7 @@ class DbMigrationEngine
     private static function loadMigrationClasses(){
         /** @var DbMigration[] $migrations */
         $migrations = [];
-        
+
         foreach(new DirectoryIterator(self::MIGRATIONS_FOLDER) as $fileInfo){
             if($fileInfo->isDot() || $fileInfo->isDir()) {
                 continue;
@@ -114,7 +114,7 @@ class DbMigrationEngine
             if(count($parts) > 1){
                 $className = $parts[1];
             }
-            
+
             include_once $fileInfo->getRealPath();
             if(class_exists($className)){
                 $reflected = new ReflectionClass($className);
@@ -123,21 +123,21 @@ class DbMigrationEngine
                 }
             }
         }
-        
+
         //Ordinamento per id, da l'ordine di esecuzione
         usort($migrations, function($a, $b){
             $aId = $a->getMigrationId();
             $bId = $b->getMigrationId();
-            
+
             if($aId == $bId){
                 return 0;
             }
             return $aId < $bId ? -1 : 1;
         });
-        
+
         return $migrations;
     }
-    
+
     /**
      * @fn performDbSetup
      * @note Decide se eseguire il setup del sistema o se è già stato eseguito e quindi va solo aggiunta la tabella
@@ -147,14 +147,14 @@ class DbMigrationEngine
      */
     private static function performDbSetup($migrations, &$lastApplied){
         $tablesCount = self::getTablesCountInDb();
-        
+
         if($tablesCount > 1){//Precedente installazione priva di Db Migrations (pre 5.6)?
             //Eseguiamo solo le migration dalla 5.6 in poi, assumendo il setup della 5.5.1 già fatto
             self::trackAppliedMigration($migrations[0]->getMigrationId());
             $lastApplied = self::getLastAppliedMigration();
         }
     }
-    
+
     /**
      * @fn getMigrationsToApply
      * @note Identifica quali migrazioni devono essere applicate in base all'ultima applicata e alla migrazione
@@ -195,7 +195,7 @@ class DbMigrationEngine
             if($targetIdx == -1){
                 throw new Exception("La Versione del Database specificata non è stata trovata");
             }
-            
+
             if($lastAppliedIdx > $targetIdx){
                 $directionUp = false;
                 $migrationsToApply = array_slice($migrations, $targetIdx +1, ($lastAppliedIdx - $targetIdx));
@@ -204,10 +204,10 @@ class DbMigrationEngine
                 $migrationsToApply = array_slice($migrations, $lastAppliedIdx +1, ($targetIdx - $lastAppliedIdx));
             }
         }
-        
+
         return $migrationsToApply;
     }
-    
+
     /**
      * @fn getTablesCountInDb
      * @note Trova il numero di tabelle presenti nel DB
@@ -216,13 +216,13 @@ class DbMigrationEngine
      */
     private static function getTablesCountInDb() {
         global $PARAMETERS;
-        
+
         $count = gdrcd_query("SELECT COUNT(*) AS number FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '"
                                     .$PARAMETERS['database']['database_name']."'");
-        
+
         return (int)$count['number'];
     }
-    
+
     /**
      * @fn createVersioningTable
      * @note Crea sul DB la tabella per il tracciamento delle versioni del DB
@@ -239,7 +239,7 @@ class DbMigrationEngine
 );
         ");
     }
-    
+
     /**
      * @fn trackAppliedMigration
      * @note Aggiunge alla tabella delle migrazioni effettuate la migrazione specificata in $migration_id
@@ -250,7 +250,7 @@ class DbMigrationEngine
     {
         gdrcd_query("INSERT INTO _gdrcd_db_versions (migration_id,applied_on) VALUE ('" . gdrcd_filter_in($migration_id) . "', NOW())");
     }
-    
+
     /**
      * @fn untrackAppliedMigration
      * @note Toglie dalla tabella delle migrazioni effettuate la migrazione specificata in $migration_id
@@ -260,7 +260,7 @@ class DbMigrationEngine
     {
         gdrcd_query("DELETE FROM _gdrcd_db_versions WHERE migration_id = '" . gdrcd_filter_in($migration_id) ."'");
     }
-    
+
     /**
      * @fn isMigrationAlreadyApplied
      * @note controlla a DB se una migrazione è già stata applicata
@@ -274,7 +274,7 @@ class DbMigrationEngine
                      ($migration_id) . "'");
         return $result['N'] > 0;
     }
-    
+
     /**
      * @fn getAllAppliedMigrations
      * @note Trova tutte le migrazioni già applicate a DB
@@ -287,10 +287,10 @@ class DbMigrationEngine
         while($row = gdrcd_query($result, 'assoc')){
             $all[] = $row;
         }
-        
+
         return $all;
     }
-    
+
     /**
      * @fn getLastAppliedMigration
      * @note Trova l'ultima migrazione applicata dalla tabella su DB
@@ -301,5 +301,5 @@ class DbMigrationEngine
     {
         return gdrcd_query("SELECT * FROM _gdrcd_db_versions ORDER BY migration_id DESC LIMIT 1");
     }
-    
+
 }

--- a/includes/DbMigration/DbMigrationEngine.class.php
+++ b/includes/DbMigration/DbMigrationEngine.class.php
@@ -109,7 +109,7 @@ class DbMigrationEngine
                 continue;
             }
             $filename = basename($fileInfo->getRealPath(), '.php');
-            $parts = explode("_", $filename);
+            $parts = explode("_", $filename, 2);
             $className = $filename;
             if(count($parts) > 1){
                 $className = $parts[1];
@@ -176,7 +176,9 @@ class DbMigrationEngine
                     break;
                 }
             }
-            $migrationsToApply = array_slice($migrations, $firstToApply);
+            $migrationsToApply = $firstToApply !== 0
+                ? array_slice($migrations, $firstToApply)
+                : [];
         }
         else{//migration verso una versione specifica
             $lastAppliedIdx = 0;


### PR DESCRIPTION
## Contenuto della PR

Questa PR risolve un problema con l'engine delle migrazioni che non riconosce correttamente files di migrazione contenenti più di un singolo underscore `_` nel nome del file.

## Nuova Convenzione Nomi

Da adesso in poi, la best practice sarà quella di avere una migrazione dedicata ad ogni specifica entità d'ora in avanti: se servono due nuove tabelle, bisognerà creare un file di migrazione distinto per ciascuna. 

I nomi dei files delle migrazioni dovrebbero essere scritti in modo da includere una descrizione di cosa la migrazione fa, secondo questo template:
```
[yyyy][mm][dd][hh][mm]_GDRCD[version]_[description].php
```

Un esempio concreto:
```
202508310218_GDRCD57_Create_Personaggio_Table.php
```

Di base sarei per dare sufficiente ibertà sui nomi delle descrizioni, ma chiederei di seguire il case dell'esempio mostrato ed eventualmente di seguire i seguenti template per uniformare le descrizioni quando possibile:
```
[Create/Drop]_[nometabella]_Table  // quando crea/rimuove una specifica tabella
[Add/Drop/Update]_[nomecolonna]_Column_In_[nometabella]_Table // quando aggiunge/elimina/modifica una colonna in una tabella esistente
[Add/Drop/Update]_[nomeindice]_Index_In_[nometabella]_Table // quando aggiunge/elimina/modifica un indice in una tabella esistente
```

Alcuni esempi:
```
Create_Personaggio_Table
Drop_Personaggio_Table

Add_Id_Column_In_Personaggio_Table
Drop_Email_Column_In_Utente_Table
Update_Descrizione_Column_In_Gilda_Table

Add_Nome_Index_In_Personaggio_Table
Drop_DataIscrizione_Index_In_Utente_Table
Update_Status_Index_In_Personaggio_Table
```

**Nota Bene:** Se si crea una tabella non è necessario separare la creazione degli indici in una distinta migration, le linee guida che riguardano colonne e indici è per quando risulta necessario aggiornarli in una migration successiva alla creazione della tabella di riferimento. 

## Motivazione 

Nel tempo, abbiamo utilizzato un sistema di migrazioni in cui il nome del file e della classe era composto semplicemente da un ID e dalla versione del software, ad esempio `2025083101_GDRCD57.php`. **Questo approccio**, però, **è poco efficace**, soprattutto nel momento in cui più persone hanno iniziato a collaborare attivamente al progetto.

Il problema principale di questa convenzione è la **mancanza di specificità**, la quale rende più difficile capire rapidamente quali modifiche sono state apportate al database e perché. Inoltre, quando più sviluppatori lavorano contemporaneamente su diverse funzionalità, diventa complicato gestire le migrazioni: ogni pull request può potenzialmente aggiungere la propria migrazione e <ins>il rischio di conflitti o sovrapposizioni è concreto e renderebbe incredibilmente ostico quel che una migrazione dovrebbe invece semplificare</ins>.

Per risolvere questi problemi, ho aggiornato il motore delle migrazioni in modo che sia possibile aggiungere una descrizione specifica nel nome della migrazione, come ad esempio `2025073023_GDRCD57_Convert_Chat_To_Utf8mb4.php`. In questo modo, il nome del file contiene sia l'ID cronologico che una breve descrizione dell'operazione svolta.

Questo approccio porta diversi vantaggi: innanzitutto, è molto più semplice capire a colpo d'occhio cosa fa una migrazione, sia per chi la scrive sia per chi la revisiona. Inoltre, ogni sviluppatore può aggiungere la propria migrazione senza preoccuparsi di entrare in conflitto con le altre, perché la descrizione rende ogni file unico e facilmente identificabile. Infine, la tracciabilità delle modifiche diventa molto più semplice, perché si può risalire rapidamente al motivo di una modifica e al suo contesto.

