### PR TITLE
[v5.7] Refactor: routing pannelli di gestione - Batch 3

### DIFF
--- a/pages/gestione/log_messaggi/action.inc.php
+++ b/pages/gestione/log_messaggi/action.inc.php
@@ -1,0 +1,99 @@
+<?php
+if (($_SESSION['permessi'] < MODERATOR) || ($PARAMETERS['mode']['spymessages'] != 'ON')) {
+    echo '<div class="error">' . gdrcd_filter('out', $MESSAGE['error']['not_allowed']) . '</div>';
+    return;
+}
+switch ($_REQUEST['op']) {
+    case 'view':
+        //Determinazione pagina (paginazione)
+                $pagebegin = (int) $_REQUEST['offset'] * $PARAMETERS['settings']['records_per_page'];
+                $pageend = $PARAMETERS['settings']['records_per_page'];
+                //Conteggio record totali
+                $record_globale = gdrcd_stmt_one("SELECT COUNT(*) FROM backmessaggi WHERE id_personaggio_mittente = ?",
+                    [$REQUEST['pg']]);
+                $totaleresults = $record_globale['COUNT(*)'];
+                //Lettura record
+                $result = gdrcd_stmt_all(
+                    "SELECT IFNULL(personaggio.nome, ?) AS destinatario,
+                            backmessaggi.spedito,
+                            backmessaggi.testo
+                    FROM backmessaggi
+                    LEFT JOIN personaggio ON backmessaggi.id_personaggio_destinatario = personaggio.id_personaggio
+                    WHERE backmessaggi.id_personaggio_mittente = ? ORDER BY backmessaggi.spedito DESC LIMIT ?, ?",
+                    [$GLOBALS['MESSAGE']['interface']['user']['cancelled'], $_REQUEST['pg'], $pagebegin, $pageend]);
+        break;
+        default:
+           echo '<div class="error">Operazione non riconosciuta.</div>';
+            return;
+        break;
+}
+if(!empty($result)) { ?>
+    <div class="elenco_record_gestione">
+            <table>
+                <!-- Intestazione tabella -->
+                <tr>
+                    <td class="casella_titolo">
+                        <div class="titoli_elenco">
+                            <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['dest']); ?>
+                        </div>
+                    </td>
+                    <td class="casella_titolo">
+                        <div class="titoli_elenco">
+                            <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['date']); ?>
+                        </div>
+                    </td>
+                    <td class="casella_titolo">
+                        <div class="titoli_elenco">
+                            <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['text']); ?>
+                        </div>
+                    </td>
+                </tr>
+                <!-- Record -->
+                <?php 
+                foreach($result as $row) { ?>
+                    <tr class="risultati_elenco_record_gestione">
+                        <td class="casella_elemento">
+                            <div class="elementi_elenco">
+                                <?php echo gdrcd_filter('out', $row['destinatario']); ?>
+                            </div>
+                        </td>
+                        <td class="casella_elemento">
+                            <div class="elementi_elenco">
+                                <?php echo gdrcd_format_date($row['spedito']).' '.gdrcd_format_time($row['spedito']); ?>
+                            </div>
+                        </td>
+                        <td class="casella_elemento">
+                            <div class="elementi_elenco">
+                                <?php echo gdrcd_filter('out', $row['testo']); ?>
+                            </div>
+                        </td>
+                    </tr>
+                <?php
+                 } //foreach
+                ?>
+            </table>
+        </div>
+        <div class="pager">
+            <?php 
+            if($totaleresults > $PARAMETERS['settings']['records_per_page']) {
+                echo gdrcd_filter('out', $MESSAGE['interface']['pager']['pages_name']);
+                for($i = 0; $i <= floor($totaleresults / $PARAMETERS['settings']['records_per_page']); $i++) {
+                    if($i != $_REQUEST['offset']) {
+                        ?>
+                        <a href="main.php?page=log_messaggi&op=view&pg=<?php echo $_REQUEST['pg']; ?>&offset=<?php echo $i; ?>"><?php echo $i + 1; ?></a>
+                    <?php 
+                    } else {
+                        echo ' '.($i + 1).' ';
+                    }
+                } //for
+            }//if
+            ?>
+        </div>
+                          
+<?php } //if(!empty($result)) ?>
+
+<div class="link_back">
+    <a href="main.php?page=log_messaggi">
+        <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['link']['back']); ?>
+    </a>
+</div>

--- a/pages/gestione/log_messaggi/index.inc.php
+++ b/pages/gestione/log_messaggi/index.inc.php
@@ -1,0 +1,46 @@
+<?php /*HELP: */
+    /*Controllo permessi utente*/
+if(($_SESSION['permessi'] < MODERATOR) || ($PARAMETERS['mode']['spymessages'] != 'ON')) {
+    echo '<div class="error">'.gdrcd_filter('out', $MESSAGE['error']['not_allowed']).'</div>';
+    return;
+}?>
+<!-- Corpo della pagina -->
+<div class="page_body">
+
+    <!-- Form di inserimento/modifica -->
+    <div class="panels_box">
+        <div class="form_gestione">
+            <form action="main.php?page=log_messaggi" method="post">
+                <?php
+                $result = gdrcd_stmt_all("SELECT nome, id_personaggio 
+                                    FROM personaggio 
+                                    WHERE permessi > ?  
+                                    ORDER BY nome", [DELETED]); 
+                ?>
+                <div class='form_label'>
+                    <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['log_type']); ?>
+                </div>
+                <div class='form_field'>
+                    <select name="pg">
+                        <?php 
+                        foreach($result as $row) { ?>
+                            <option value="<?php echo gdrcd_filter('out', $row['id_personaggio']); ?>">
+                                <?php echo gdrcd_filter('out', $row['nome']); ?>
+                            </option>
+                        <?php 
+                        }//foreach
+                        ?>
+                    </select>
+                </div>
+                <!-- bottoni -->
+                <div class='form_submit'>
+                    <input type="hidden" value="view" name="op" />
+                    <input type="submit" value="<?php echo gdrcd_filter('out', $MESSAGE['interface']['forms']['submit']); ?>" />
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="link_back">
+        <a href="main.php?page=gestione">Torna indietro</a>
+    </div>
+</div>

--- a/pages/log_messaggi.inc.php
+++ b/pages/log_messaggi.inc.php
@@ -1,136 +1,26 @@
-<div class="pagina_gestione_razze">
+<div class="pagina_log_messaggi">
     <?php /*HELP: */
     /*Controllo permessi utente*/
-    if(($_SESSION['permessi'] < MODERATOR) || ($PARAMETERS['mode']['spymessages'] != 'ON')) {
-        echo '<div class="error">'.gdrcd_filter('out', $MESSAGE['error']['not_allowed']).'</div>';
+    if (($_SESSION['permessi'] < MODERATOR) || ($PARAMETERS['mode']['spymessages'] != 'ON')){
+        
+        echo '<div class="error">'.gdrcd_filter('out',$MESSAGE['error']['not_allowed']).'</div>';
     } else { ?>
-        <!-- Titolo della pagina -->
-        <div class="page_title">
-            <h2><?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['page_name']); ?></h2>
-        </div>
-        <!-- Corpo della pagina -->
-        <div class="page_body">
-            <?php /*Form di scelta del log (visualizzazione di base)*/
-            if((isset($_POST['op']) === false) && (isset($_REQUEST['op']) === false)) { ?>
-                <!-- Form di inserimento/modifica -->
-                <div class="panels_box">
-                    <div class="form_gestione">
-                        <form action="main.php?page=log_messaggi" method="post">
-                            <?php
-                            $result = gdrcd_query("SELECT nome, id_personaggio FROM personaggio WHERE permessi > ".DELETED." ORDER BY nome", 'result'); ?>
-                            <div class='form_label'>
-                                <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['log_type']); ?>
-                            </div>
-                            <div class='form_field'>
-                                <select name="pg">
-                                    <?php while($row = gdrcd_query($result, 'fetch')) { ?>
-                                        <option value="<?php echo gdrcd_filter('out', $row['id_personaggio']); ?>">
-                                            <?php echo gdrcd_filter('out', $row['nome']); ?>
-                                        </option>
-                                    <?php }//while
-                                    gdrcd_query($result, 'free');
-                                    ?>
-                                </select>
-                            </div>
-                            <!-- bottoni -->
-                            <div class='form_submit'>
-                                <input type="hidden" value="view" name="op" />
-                                <input type="submit" value="<?php echo gdrcd_filter('out', $MESSAGE['interface']['forms']['submit']); ?>" />
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            <?php
-            }//if ?
-            //*Elenco log*/
-            if(isset($_REQUEST['op']) == 'view') {
-                //Determinazione pagina (paginazione)
-                $pagebegin = (int) $_REQUEST['offset'] * $PARAMETERS['settings']['records_per_page'];
-                $pageend = $PARAMETERS['settings']['records_per_page'];
-                //Conteggio record totali
-                $record_globale = gdrcd_query("SELECT COUNT(*) FROM backmessaggi WHERE id_personaggio_mittente = '".gdrcd_filter('in', $_REQUEST['pg'])."'");
-                $totaleresults = $record_globale['COUNT(*)'];
-                //Lettura record
-                $result = gdrcd_stmt(
-                    "SELECT IFNULL(personaggio.nome, ?) AS destinatario,
-                            backmessaggi.spedito,
-                            backmessaggi.testo
-                    FROM backmessaggi
-                    LEFT JOIN personaggio ON backmessaggi.id_personaggio_destinatario = personaggio.id_personaggio
-                    WHERE backmessaggi.id_personaggio_mittente = ? ORDER BY backmessaggi.spedito DESC LIMIT ?, ?",
-                    [$GLOBALS['MESSAGE']['interface']['user']['cancelled'], $_REQUEST['pg'], $pagebegin, $pageend]);
-                $numresults = gdrcd_query($result, 'num_rows');
+    <div class="page_title">
+        <h2>Log messaggi</h2>
+    </div>
+    <div class="page_body">
+        <?php
+        switch($_REQUEST['op']) {
+            case 'view': // Visualizzazione log messaggi
+            
+                include('gestione/log_messaggi/action.inc.php');
+                break;
 
-                /* Se esistono record */
-                if($numresults > 0) { ?>
-                    <!-- Elenco dei record paginato -->
-                    <div class="elenco_record_gestione">
-                        <table>
-                            <!-- Intestazione tabella -->
-                            <tr>
-                                <td class="casella_titolo">
-                                    <div class="titoli_elenco">
-                                        <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['dest']); ?>
-                                    </div>
-                                </td>
-                                <td class="casella_titolo">
-                                    <div class="titoli_elenco">
-                                        <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['date']); ?>
-                                    </div>
-                                </td>
-                                <td class="casella_titolo">
-                                    <div class="titoli_elenco">
-                                        <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['text']); ?>
-                                    </div>
-                                </td>
-                            </tr>
-                            <!-- Record -->
-                            <?php while($row = gdrcd_query($result, 'assoc')) { ?>
-                                <tr class="risultati_elenco_record_gestione">
-                                    <td class="casella_elemento">
-                                        <div class="elementi_elenco">
-                                            <?php echo gdrcd_filter('out', $row['destinatario']); ?>
-                                        </div>
-                                    </td>
-                                    <td class="casella_elemento">
-                                        <div class="elementi_elenco">
-                                            <?php echo gdrcd_format_date($row['spedito']).' '.gdrcd_format_time($row['spedito']); ?>
-                                        </div>
-                                    </td>
-                                    <td class="casella_elemento">
-                                        <div class="elementi_elenco">
-                                            <?php echo gdrcd_filter('out', $row['testo']); ?>
-                                        </div>
-                                    </td>
-                                </tr>
-                            <?php } //while
-                            gdrcd_query($result, 'free');
-                            ?>
-                        </table>
-                    </div>
-                <?php }//if  ?>
-                <!-- Paginatore elenco -->
-                <div class="pager">
-                    <?php if($totaleresults > $PARAMETERS['settings']['records_per_page']) {
-                        echo gdrcd_filter('out', $MESSAGE['interface']['pager']['pages_name']);
-                        for($i = 0; $i <= floor($totaleresults / $PARAMETERS['settings']['records_per_page']); $i++) {
-                            if($i != $_REQUEST['offset']) {
-                                ?>
-                                <a href="main.php?page=log_messaggi&op=view&pg=<?php echo $_REQUEST['pg']; ?>&offset=<?php echo $i; ?>"><?php echo $i + 1; ?></a>
-                            <?php } else {
-                                echo ' '.($i + 1).' ';
-                            }
-                        } //for
-                    }//if
-                    ?>
-                </div>
-                <!-- link crea nuovo -->
-                <div class="link_back">
-                    <a href="main.php?page=log_messaggi">
-                        <?php echo gdrcd_filter('out', $MESSAGE['interface']['administration']['log']['messages']['link']['back']); ?>
-                    </a>
-                </div>
-            <?php }//else ?>
-        </div>
-    <?php }//else (controllo permessi utente) ?>
-</div><!--Pagina-->
+            default: //Lista pagine
+                include('gestione/log_messaggi/index.inc.php');
+                break;
+        }
+    }
+        ?>
+    </div><!-- page_body -->
+</div><!-- Pagina -->


### PR DESCRIPTION
Aggiunge gestione/log_messaggi/action.inc.php e gestione/log_messaggi/index.inc.php e rifattorizza pages/log_messaggi.inc.php per utilizzarli.

La logica di visualizzazione/elenco e la paginazione sono state spostate nel nuovo file di action, mentre il form di selezione è stato spostato nel nuovo file index; pages/log_messaggi.inc.php ora delega tramite uno switch e include questi file.

L’accesso al database è stato aggiornato per usare gli helper gdrcd_stmt_* tramite prepared statement, mentre i controlli dei permessi e il markup sono stati ripuliti.

Nel complesso, questa modifica separa la logica di presentazione dalla logica di azione per il log dei messaggi.